### PR TITLE
Fix post previews rendering raw markdown

### DIFF
--- a/blog/post.go
+++ b/blog/post.go
@@ -2,7 +2,9 @@ package blog
 
 import (
 	"bytes"
+	"html/template"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -34,6 +36,93 @@ func (p Post) PreviewContent(length int) string {
 		return string(runes[:length])
 	}
 	return string(runes)
+}
+
+var (
+	reFencedCode = regexp.MustCompile("(?s)```[^\n]*\n(.*?)```")
+	reInlineCode = regexp.MustCompile("`([^`]+)`")
+	reImages     = regexp.MustCompile(`!\[([^\]]*)\]\([^)]+\)`)
+	reLinks        = regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
+	reLinksWithURL = regexp.MustCompile(`\[([^\]]+)\]\(([^)]+)\)`)
+	reHeadings     = regexp.MustCompile(`(?m)^#{1,6}\s+`)
+	reBold       = regexp.MustCompile(`\*\*(.+?)\*\*`)
+	reItalic     = regexp.MustCompile(`\*(.+?)\*`)
+	reUBold      = regexp.MustCompile(`__(.+?)__`)
+	reUItalic    = regexp.MustCompile(`_(.+?)_`)
+	reHR         = regexp.MustCompile(`(?m)^[-*_]{3,}\s*$`)
+	reWhitespace = regexp.MustCompile(`\s+`)
+)
+
+// PlainTextPreview strips markdown syntax and returns clean plain text for previews
+func (p Post) PlainTextPreview(length int) string {
+	s := p.Content
+	s = reFencedCode.ReplaceAllString(s, "$1")
+	s = reInlineCode.ReplaceAllString(s, "$1")
+	s = reImages.ReplaceAllString(s, "$1")
+	s = reLinks.ReplaceAllString(s, "$1")
+	s = reHeadings.ReplaceAllString(s, "")
+	s = reBold.ReplaceAllString(s, "$1")
+	s = reItalic.ReplaceAllString(s, "$1")
+	s = reUBold.ReplaceAllString(s, "$1")
+	s = reUItalic.ReplaceAllString(s, "$1")
+	s = reHR.ReplaceAllString(s, "")
+	s = reWhitespace.ReplaceAllString(s, " ")
+	s = strings.TrimSpace(s)
+
+	runes := bytes.Runes([]byte(s))
+	if len(runes) > length {
+		return string(runes[:length]) + "..."
+	}
+	return s
+}
+
+// HTMLPreview strips markdown syntax but preserves links as HTML hyperlinks
+func (p Post) HTMLPreview(length int) template.HTML {
+	s := p.Content
+	s = reFencedCode.ReplaceAllString(s, "<code>$1</code>")
+	s = reInlineCode.ReplaceAllString(s, "<code>$1</code>")
+	s = reImages.ReplaceAllString(s, "$1")
+	s = reLinksWithURL.ReplaceAllString(s, `<a href="$2">$1</a>`)
+	s = reHeadings.ReplaceAllString(s, "")
+	s = reBold.ReplaceAllString(s, "$1")
+	s = reItalic.ReplaceAllString(s, "$1")
+	s = reUBold.ReplaceAllString(s, "$1")
+	s = reUItalic.ReplaceAllString(s, "$1")
+	s = reHR.ReplaceAllString(s, "")
+	s = reWhitespace.ReplaceAllString(s, " ")
+	s = strings.TrimSpace(s)
+
+	// Truncate by visible character count, skipping HTML tags
+	runes := []rune(s)
+	visible := 0
+	cutoff := len(runes)
+	inTag := false
+	for i, r := range runes {
+		if r == '<' {
+			inTag = true
+		} else if r == '>' {
+			inTag = false
+		} else if !inTag {
+			visible++
+			if visible > length {
+				cutoff = i
+				break
+			}
+		}
+	}
+
+	if cutoff < len(runes) {
+		result := string(runes[:cutoff])
+		if strings.Count(result, "<a ") > strings.Count(result, "</a>") {
+			result += "</a>"
+		}
+		if strings.Count(result, "<code>") > strings.Count(result, "</code>") {
+			result += "</code>"
+		}
+		result += "..."
+		return template.HTML(result)
+	}
+	return template.HTML(s)
 }
 
 // Permalink returns the link to the post relative to root

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -44,7 +44,7 @@
         {{ end }}
       </p>
       <p class="text-justify">
-        {{ .recent.PreviewContent 600 }} ...
+        {{ .recent.HTMLPreview 300 }}
       </p>
     </div>
   </div>

--- a/templates/header.html
+++ b/templates/header.html
@@ -8,7 +8,7 @@
   <meta name="robots" content="index, follow" />
   <meta property="og:site_name" content="{{ .settings.site_title.Value }}">
   {{ if .post }}
-  <meta name="description" content="{{ .post.PreviewContent 155 }}">
+  <meta name="description" content="{{ .post.PlainTextPreview 155 }}">
   <meta property="og:title" content="{{ .settings.site_title.Value }}: {{ .post.Title }}">
   <meta property="og:type" content="article">
   <meta property="og:url" content="https://www.jasonernst.com{{ .post.Permalink }}">

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -22,7 +22,7 @@
               {{ end }}
           </p>
           <p class="text-justify">
-            {{ .PreviewContent 200 }} ...
+            {{ .HTMLPreview 200 }}
           </p>
 
       </div>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -12,7 +12,7 @@
           <h2 class="text-left"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
           <p class="blog-post-meta text-left">{{ .CreatedAt.Format "Jan 02, 2006 15:04:05 UTC" }}</p>
           <p class="text-left">
-            {{ .PreviewContent 100 }} ...
+            {{ .HTMLPreview 100 }}
           </p>
 
       </div>


### PR DESCRIPTION
## Summary
- Post previews were displaying raw markdown syntax (`[text](url)`, fenced code blocks, `**bold**`, etc.) because `PreviewContent()` simply truncated the raw content string
- Add `PlainTextPreview()` that strips markdown to clean text (used for `<meta description>` tag)
- Add `HTMLPreview()` that preserves links as clickable `<a>` tags and renders inline/fenced code as `<code>` elements, with visible-character-aware truncation so HTML tags don't consume preview length

## Test plan
- [x] `go test ./...` passes
- [ ] Footer "Most Recent Post" shows clean preview with clickable links and styled code
- [ ] `/posts` page shows clean previews
- [ ] `/tag/:name` pages show clean previews
- [ ] Full post pages still render markdown normally via Showdown.js
- [ ] Meta description in page source contains plain text (no HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)