### PR TITLE
Fix tags with slash in name breaking routes

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -137,7 +137,7 @@ func (b *Blog) getPostByParams(year int, month int, day int, slug string) (*Post
 func (b *Blog) getPostsByTag(c *gin.Context) ([]Post, error) {
 	var posts []Post
 	var tag Tag
-	name := c.Param("name")
+	name := strings.TrimPrefix(c.Param("name"), "/")
 	if err := (*b.db).Where("name = ?", name).First(&tag).Error; err != nil {
 		return nil, errors.New("No tag named " + name)
 	}
@@ -306,7 +306,7 @@ func (b *Blog) Post(c *gin.Context) {
 
 // Tag lists all posts with a given tag
 func (b *Blog) Tag(c *gin.Context) {
-	tag := c.Param("name")
+	tag := strings.TrimPrefix(c.Param("name"), "/")
 	posts, err := b.getPostsByTag(c)
 	if err != nil {
 		c.HTML(http.StatusNotFound, "error.html", gin.H{

--- a/blog/blog_test.go
+++ b/blog/blog_test.go
@@ -58,7 +58,7 @@ func TestBlogWorkflow(t *testing.T) {
 
 	//html requests
 	router.GET("/posts/:yyyy/:mm/:dd/:slug", b.Post)
-	router.GET("/tag/:name", b.Tag)
+	router.GET("/tag/*name", b.Tag)
 	router.GET("/posts", b.Posts)
 	router.GET("/tags", b.Tags)
 	router.GET("/", b.Home)

--- a/goblog.go
+++ b/goblog.go
@@ -357,7 +357,7 @@ func (g goblog) addRoutes() {
 	// lets posts work with our without the word posts in front
 	g.router.GET("/:yyyy/:mm/:dd/:slug", g._blog.Post)
 	g.router.GET("/admin/posts/:yyyy/:mm/:dd/:slug", g._admin.Post)
-	g.router.GET("/tag/:name", g._blog.Tag)
+	g.router.GET("/tag/*name", g._blog.Tag)
 	g.router.GET("/logout", g._blog.Logout)
 
 	//todo: register a template mapping to a "page type"

--- a/templates/post-admin.html
+++ b/templates/post-admin.html
@@ -13,7 +13,7 @@
         <p class="blog-post-meta text-left">Posted on {{ .post.CreatedAt.Format "Jan 02, 2006 15:04:05 UTC" }}. Last Edited on {{ .post.UpdatedAt.Format "Jan 02, 2006 15:04:05 UTC" }} [ <a href="#" onclick="return deletePost($post.ID)">Delete</a>] </p>
         <p class="tags text-left">
           {{range .post.Tags}}
-            <a href="/tag/{{.Name}}">#{{.Name}}</a>
+            <a href="{{ .Permalink }}">#{{.Name}}</a>
           {{end}}
         </p>
       </div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -11,7 +11,7 @@
         <p class="blog-post-meta text-left">Posted on {{ .post.CreatedAt.Format "Jan 02, 2006 15:04:05 UTC" }}. Last Edited on {{ .post.UpdatedAt.Format "Jan 02, 2006 15:04:05 UTC" }} </p>
         <p class="tags text-left">
           {{range .post.Tags}}
-            <a href="/tag/{{.Name}}">#{{.Name}}</a>
+            <a href="{{ .Permalink }}">#{{.Name}}</a>
           {{end}}
         </p>
         {{ if .is_admin }}


### PR DESCRIPTION
Fixes https://github.com/compscidr/goblog/issues/55

## Summary
- Tags containing `/` (e.g. `c/c++`) broke because Gin's `:name` route parameter stops capturing at the first `/`, so `/tag/c/c++` only matched `c`
- Switch to `*name` wildcard parameter which captures the full path including slashes
- Trim the leading `/` that wildcard params include from the captured value
- Update `post.html` and `post-admin.html` templates to use `.Permalink()` instead of hardcoding `/tag/{{.Name}}`

## Test plan
- [x] `go test ./...` passes
- [ ] Navigate to a tag page with `/` in the name (e.g. `c/c++`) — should load correctly
- [ ] Tag links on post pages still work for regular tags
- [ ] `/tags` index page links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)