### PR TITLE
Sort research articles by date (newest first)

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -56,6 +56,19 @@ func (b *Blog) IsDbNil() bool {
 	return (*b.db) == nil
 }
 
+// sortArticlesByDateDesc sorts scholar articles by publication date in descending order.
+func sortArticlesByDateDesc(articles []*scholar.Article) {
+	sort.Slice(articles, func(i, j int) bool {
+		if articles[i].Year != articles[j].Year {
+			return articles[i].Year > articles[j].Year
+		}
+		if articles[i].Month != articles[j].Month {
+			return articles[i].Month > articles[j].Month
+		}
+		return articles[i].Day > articles[j].Day
+	})
+}
+
 // Generic Functions (not JSON or HTML)
 func (b *Blog) GetPosts(drafts bool) []Post {
 	var posts []Post
@@ -335,15 +348,7 @@ func (b *Blog) DynamicPage(c *gin.Context, page *Page) {
 	case PageTypeResearch:
 		articles, err := b.scholar.QueryProfileWithMemoryCache(page.ScholarID, 50)
 		if err == nil {
-			sort.Slice(articles, func(i, j int) bool {
-				if articles[i].Year != articles[j].Year {
-					return articles[i].Year > articles[j].Year
-				}
-				if articles[i].Month != articles[j].Month {
-					return articles[i].Month > articles[j].Month
-				}
-				return articles[i].Day > articles[j].Day
-			})
+			sortArticlesByDateDesc(articles)
 			b.scholar.SaveCache("profiles.json", "articles.json")
 			c.HTML(http.StatusOK, "page_research.html", gin.H{
 				"logged_in":  b.auth.IsLoggedIn(c),
@@ -673,15 +678,7 @@ func (b *Blog) Speaking(c *gin.Context) {
 func (b *Blog) Research(c *gin.Context) {
 	articles, err := b.scholar.QueryProfileWithMemoryCache("SbUmSEAAAAAJ", 50)
 	if err == nil {
-		sort.Slice(articles, func(i, j int) bool {
-			if articles[i].Year != articles[j].Year {
-				return articles[i].Year > articles[j].Year
-			}
-			if articles[i].Month != articles[j].Month {
-				return articles[i].Month > articles[j].Month
-			}
-			return articles[i].Day > articles[j].Day
-		})
+		sortArticlesByDateDesc(articles)
 		b.scholar.SaveCache("profiles.json", "articles.json")
 		c.HTML(http.StatusOK, "research.html", gin.H{
 			"logged_in":  b.auth.IsLoggedIn(c),

--- a/blog/sort_test.go
+++ b/blog/sort_test.go
@@ -1,0 +1,25 @@
+package blog
+
+import (
+	scholar "github.com/compscidr/scholar"
+	"testing"
+)
+
+func TestSortArticlesByDateDesc(t *testing.T) {
+	articles := []*scholar.Article{
+		{Title: "Old", Year: 2020, Month: 3, Day: 15},
+		{Title: "Newest", Year: 2025, Month: 1, Day: 10},
+		{Title: "SameYearLater", Year: 2023, Month: 11, Day: 5},
+		{Title: "SameYearEarlier", Year: 2023, Month: 2, Day: 20},
+		{Title: "SameYearMonth", Year: 2023, Month: 11, Day: 1},
+	}
+
+	sortArticlesByDateDesc(articles)
+
+	expected := []string{"Newest", "SameYearLater", "SameYearMonth", "SameYearEarlier", "Old"}
+	for i, title := range expected {
+		if articles[i].Title != title {
+			t.Errorf("position %d: expected %q, got %q", i, title, articles[i].Title)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Sort research/scholar articles by publication date (year, month, day) in descending order so newest publications appear first
- Applied to both the dynamic page research handler and the legacy research handler

Fixes #345

## Test plan
- [ ] Visit the research page and verify articles are sorted with most recent publications at the top
- [ ] Verify articles with the same year are further sorted by month/day

🤖 Generated with [Claude Code](https://claude.com/claude-code)