### PR TITLE
Fix tag duplication when saving posts

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -182,21 +182,35 @@ func (a *Admin) UpdatePost(c *gin.Context) {
 	existingPost.CreatedAt = requestPost.CreatedAt
 	existingPost.Draft = requestPost.Draft
 	existingPost.PostTypeID = requestPost.PostTypeID
-	(*a.db).Model(&existingPost).Where("id = ?", requestPost.ID).Updates(&existingPost)
 
-	// Replace tag associations atomically to avoid duplication
-	(*a.db).Model(&existingPost).Association("Tags").Replace(requestPost.Tags)
-
-	//https://stackoverflow.com/questions/56653423/gorm-doesnt-update-boolean-field-to-false
-	if !requestPost.Draft {
-		(*a.db).Model(&existingPost).Select("draft").Update("draft", false)
+	txErr := (*a.db).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&existingPost).Where("id = ?", requestPost.ID).Updates(&existingPost).Error; err != nil {
+			return err
+		}
+		// Replace tag associations atomically to avoid duplication
+		if err := tx.Model(&existingPost).Association("Tags").Replace(requestPost.Tags); err != nil {
+			return err
+		}
+		//https://stackoverflow.com/questions/56653423/gorm-doesnt-update-boolean-field-to-false
+		if !requestPost.Draft {
+			if err := tx.Model(&existingPost).Select("draft").Update("draft", false).Error; err != nil {
+				return err
+			}
+		}
+		// Explicitly update post_type_id since GORM's struct-based Updates may skip it
+		if err := tx.Model(&existingPost).Select("post_type_id").Update("post_type_id", requestPost.PostTypeID).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+	if txErr != nil {
+		log.Println("ERROR UPDATING POST: ", txErr)
+		c.JSON(http.StatusInternalServerError, "Failed to update post")
+		return
 	}
 
-	// Explicitly update post_type_id since GORM's struct-based Updates may skip it
-	(*a.db).Model(&existingPost).Select("post_type_id").Update("post_type_id", requestPost.PostTypeID)
-
-	// Reload with PostType for JSON response
-	(*a.db).Preload("PostType").First(&existingPost, existingPost.ID)
+	// Reload with PostType and Tags for JSON response
+	(*a.db).Preload("PostType").Preload("Tags").First(&existingPost, existingPost.ID)
 
 	a.b.ComputeBacklinks(&existingPost)
 

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -188,7 +188,9 @@ func TestCreatePost(t *testing.T) {
 		t.Fatalf("Expected status %d but got %d\n", http.StatusAccepted, w.Code)
 	}
 	var updatedPost blog.Post
-	json.Unmarshal(w.Body.Bytes(), &updatedPost)
+	if err := json.Unmarshal(w.Body.Bytes(), &updatedPost); err != nil {
+		t.Fatalf("Failed to unmarshal updated post response: %v", err)
+	}
 	// reload with tags
 	db.Preload("Tags").First(&updatedPost, post.ID)
 	if len(updatedPost.Tags) != 2 {


### PR DESCRIPTION
## Summary
- Replace `Association("Tags").Clear()` + struct-based `Updates()` with `Association("Tags").Replace()` to atomically swap tag associations without duplication
- Remove `Tags` from the struct passed to `Updates()` so GORM doesn't re-insert them
- Add missing `Tag` migration to admin test setup
- Add test that saves a post with tags twice and verifies the count stays at 2

Closes #487

## Test plan
- [x] Existing tests pass
- [x] New test verifies tags don't double on repeated saves
- [ ] Manual: edit a post with tags, save multiple times, confirm tag count stays stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)