### PR TITLE
Fix login page recent posts alignment

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -38,4 +38,8 @@
         &nbsp;
       </div>
 
+    </div> <!-- /container (github button) -->
+  </div> <!-- /container align-self-center -->
+</div> <!-- /full-height row text-center -->
+
 {{ template "footer.html" .}}


### PR DESCRIPTION
## Summary
- Close the three unclosed `<div>` tags (`full-height row text-center`, `container align-self-center`, inner `container`) in `login.html` before the footer template inclusion
- This prevents the `text-center` class from cascading into the footer's "Most Recent Post" section

Closes #486

## Test plan
- [ ] Visit the login page and verify the "Most Recent Post" section in the footer is left-aligned, matching other pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)