### PR TITLE
Filter draft posts from most recent post

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -82,7 +82,7 @@ func (b *Blog) GetPosts(drafts bool) []Post {
 
 func (b *Blog) GetLatest() Post {
 	var post Post
-	(*b.db).Preload("Tags").Preload("PostType").Order("created_at desc").First(&post)
+	(*b.db).Preload("Tags").Preload("PostType").Where("draft = ?", false).Order("created_at desc").First(&post)
 	return post
 }
 


### PR DESCRIPTION
## Summary
- Add `Where("draft = ?", false)` to `GetLatest()` so draft posts don't appear in the "Most Recent Post" footer section

Closes #501

## Test plan
- [ ] Create a draft post, verify it doesn't appear in the footer's "Most Recent Post"
- [ ] Verify a published post still appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)