### PR TITLE
Auto-promote first OAuth login to admin when no admin exists

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -189,12 +189,33 @@ func (a *Auth) LoginPostHandler(c *gin.Context) {
 		existingUser = *user
 	}
 
+	// On a fresh install where the operator has pre-populated .env (e.g. via
+	// configuration management), the install wizard's UI flow is bypassed and
+	// no admin user is ever created. Promote the first successful OAuth login
+	// to admin so the operator can administer the site without re-running the
+	// wizard. Same trust model as the wizard: whoever first completes OAuth
+	// against the server's client_secret becomes the admin.
+	if err := a.EnsureAdmin(user.ID); err != nil {
+		log.Println("Error ensuring admin user: " + err.Error())
+	}
+
 	//save the access token in the session
 	session := sessions.Default(c)
 	session.Set("token", data.AccessToken)
 	session.Save()
 
 	c.JSON(http.StatusOK, existingUser)
+}
+
+// EnsureAdmin promotes the given BlogUser to admin if and only if no admin
+// user currently exists. Idempotent and safe to call on every login.
+func (a *Auth) EnsureAdmin(blogUserID int) error {
+	var existing AdminUser
+	err := (*a.db).First(&existing).Error
+	if err == nil {
+		return nil // an admin already exists; nothing to do
+	}
+	return (*a.db).Create(&AdminUser{BlogUserID: blogUserID}).Error
 }
 
 // DisplayUserTable is a debug function, shows the user table

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -209,13 +209,23 @@ func (a *Auth) LoginPostHandler(c *gin.Context) {
 
 // EnsureAdmin promotes the given BlogUser to admin if and only if no admin
 // user currently exists. Idempotent and safe to call on every login.
+//
+// The check-and-create runs inside a transaction so two concurrent first
+// logins can't both observe an empty admin_users table and both create a
+// row. Lookup errors other than "record not found" are surfaced rather
+// than swallowed as if no admin existed.
 func (a *Auth) EnsureAdmin(blogUserID int) error {
-	var existing AdminUser
-	err := (*a.db).First(&existing).Error
-	if err == nil {
-		return nil // an admin already exists; nothing to do
-	}
-	return (*a.db).Create(&AdminUser{BlogUserID: blogUserID}).Error
+	return (*a.db).Transaction(func(tx *gorm.DB) error {
+		var existing AdminUser
+		err := tx.First(&existing).Error
+		if err == nil {
+			return nil // an admin already exists; nothing to do
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		return tx.Create(&AdminUser{BlogUserID: blogUserID}).Error
+	})
 }
 
 // DisplayUserTable is a debug function, shows the user table

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -60,3 +60,48 @@ func TestIsWizardMode_WithAdminUser_ReturnsFalse(t *testing.T) {
 		t.Fatal("IsWizardMode must be false once an admin_users row exists")
 	}
 }
+
+func TestEnsureAdmin_NoAdmin_CreatesRow(t *testing.T) {
+	a, db := newAuth(t)
+	user := auth.BlogUser{ID: 42, Login: "operator"}
+	db.Create(&user)
+
+	if err := a.EnsureAdmin(user.ID); err != nil {
+		t.Fatalf("EnsureAdmin: %v", err)
+	}
+
+	var count int64
+	db.Model(&auth.AdminUser{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("expected 1 admin_users row, got %d", count)
+	}
+	var got auth.AdminUser
+	db.First(&got)
+	if got.BlogUserID != user.ID {
+		t.Fatalf("expected admin BlogUserID=%d, got %d", user.ID, got.BlogUserID)
+	}
+}
+
+func TestEnsureAdmin_AdminExists_NoOp(t *testing.T) {
+	a, db := newAuth(t)
+	first := auth.BlogUser{ID: 1, Login: "first"}
+	second := auth.BlogUser{ID: 2, Login: "second"}
+	db.Create(&first)
+	db.Create(&second)
+	db.Create(&auth.AdminUser{BlogUserID: first.ID, BlogUser: first})
+
+	if err := a.EnsureAdmin(second.ID); err != nil {
+		t.Fatalf("EnsureAdmin: %v", err)
+	}
+
+	var count int64
+	db.Model(&auth.AdminUser{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("expected EnsureAdmin to be a no-op when an admin exists, got %d admin rows", count)
+	}
+	var got auth.AdminUser
+	db.First(&got)
+	if got.BlogUserID != first.ID {
+		t.Fatalf("expected first admin to remain (id=%d), got id=%d", first.ID, got.BlogUserID)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the second half of #529.

When \`.env\` is pre-populated by configuration management on a fresh install, \`rootHandler\` only checks \`.env\` (not the DB) when deciding whether to show the install wizard, so the wizard's UI flow is skipped entirely. The wizard is the only existing path that creates an \`admin_users\` row, so the site comes up with no admin user. After #530 made \`IsAdmin\` strict, the symptom for the operator becomes: \`/login\` and \`/logout\` work, the OAuth dance succeeds, the BlogUser is created — but no admin link, no admin pages, no way to administer the site.

This PR adds \`Auth.EnsureAdmin(blogUserID)\` and calls it from \`LoginPostHandler\` after a successful OAuth login. It promotes the logging-in user to admin if and only if no \`admin_users\` row exists yet — same trust model as the wizard's \`updateAdminUser\` (whoever first completes OAuth against the server's \`client_secret\` becomes the admin), but reachable from the regular login path so an operator who pre-populates \`.env\` can finish setup just by clicking \"Sign in with GitHub\".

The wizard's own flow is unchanged: it still runs when \`.env\` is missing or incomplete, still ends in \`updateAdminUser\`. \`EnsureAdmin\` is idempotent — once an admin exists, subsequent logins are pure authentications and no promotion happens.

## Tests

\`auth/auth_test.go\` covers:
- \`EnsureAdmin\` creates a row when none exists and points to the supplied \`BlogUserID\`.
- \`EnsureAdmin\` is a no-op when an admin already exists (the existing admin is preserved; a second caller doesn't get promoted).

\`\`\`
ok  	goblog/admin	0.029s
ok  	goblog/auth	0.007s
ok  	goblog/blog	0.028s
\`\`\`

## Note on the trust model

Anyone with a GitHub account can complete OAuth against the public site's \`/login\`, so \"first to log in becomes admin\" is a race that the operator has to win on first deploy. This is unchanged from the existing wizard flow, which has the same race. A stricter model (e.g. configuring an expected GitHub login in \`.env\` and only promoting that user) is a reasonable follow-up but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)